### PR TITLE
feat: add notification router and team topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+/**/.vscode/
+*.code-workspace
+
+**/template-packaged.yaml
+**/.aws-sam
+
+.idea/
+
 # dependencies
 /node_modules
 /.pnp

--- a/notifications/.cfnlintrc
+++ b/notifications/.cfnlintrc
@@ -1,0 +1,7 @@
+# Refer to https://github.com/aws-cloudformation/cfn-python-lint/
+templates:
+- template.yaml
+regions:
+- us-east-1
+include_checks:
+  - I

--- a/notifications/samconfig.toml
+++ b/notifications/samconfig.toml
@@ -1,0 +1,32 @@
+version=0.1
+
+[default.global.parameters]
+stack_name = "team-elevated-access-notifications"
+s3_prefix = "db-aws-iam-identity-center-team"
+tags = "doosan:repo=\"https://github.com/DoosanICA/db-aws-iam-identity-center-team\" doosan:owner=\"DI_OPERATIONS\""
+
+profile = "security"
+region = "us-east-1"
+confirm_changeset = true
+capabilities = "CAPABILITY_NAMED_IAM"
+fail_on_empty_changeset = false
+s3_bucket = "dibh-196522590087-us-east-1-cloudformation"
+output_template_file="template-packaged.yaml"
+role_arn="arn:aws:iam::196522590087:role/CloudFormationDeployer"
+
+
+[github.global.parameters]
+stack_name =  "team-elevated-access-notifications"
+s3_prefix = "db-aws-iam-identity-center-team"
+tags = "doosan:repo=\"https://github.com/DoosanICA/db-aws-iam-identity-center-team\" doosan:owner=\"DI_OPERATIONS\""
+
+region = "us-east-1"
+capabilities = "CAPABILITY_NAMED_IAM"
+fail_on_empty_changeset = false
+output_template_file="template-packaged.yaml"
+
+[default.deploy.parameters]
+template_file = "template-packaged.yaml"
+
+[github.deploy.parameters]
+template_file = "template-packaged.yaml"

--- a/notifications/template.yaml
+++ b/notifications/template.yaml
@@ -1,0 +1,234 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Notifications for TEAM Requests
+
+Mappings:
+  Settings:
+    TopicSuffix:
+      value: team-access-requests
+    TeamNotificationsTopic:
+      arn: arn:aws:sns:us-east-1:196522590087:TeamNotifications-main
+    RoutingFunction:
+      name: elevated-access-request-router
+  TeamSpecific:
+    DIOps:
+      ChannelEmail: 815d6a88.Doosan.onmicrosoft.com@amer.teams.ms # DI Operations - TEAM Access Requests
+
+    
+Resources:
+
+  RequestRouterSqsQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      QueueName: !Sub
+        - request-router-${TopicSuffix}
+        - TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+      SqsManagedSseEnabled: true
+      MessageRetentionPeriod: 28800 # 8 hours
+      ReceiveMessageWaitTimeSeconds: 20
+  
+  RouterQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref RequestRouterSqsQueue
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action:
+              - sqs:SendMessage
+              - sqs:SendMessageBatch
+            Resource: !GetAtt RequestRouterSqsQueue.Arn
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !FindInMap [Settings, TeamNotificationsTopic, arn]
+
+  NotificationSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Protocol: sqs
+      TopicArn: !FindInMap [Settings, TeamNotificationsTopic, arn]
+      Endpoint: !GetAtt RequestRouterSqsQueue.Arn
+
+  # SnsTopicPolicy:
+  #   Type: AWS::SNS::TopicPolicy
+  #   Properties:
+  #     PolicyDocument:
+  #       Version: '2012-10-17'
+  #       Statement:
+  #         - Effect: Allow
+  #           Principal:
+  #             Service: sns.amazonaws.com
+  #           Action:
+  #             - sns:Publish
+  #           Resource: '*-team-access-requests'
+  #           Condition:
+  #             ArnEquals:
+  #               aws:SourceArn: !Sub
+  #                 - arn:${AWS::Region}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}
+  #                 - FunctionName: !FindInMap [Settings, RoutingFunction, name]
+  #     Topics:
+  #       - !Ref DIOpsSnsTopic
+  #       - !Ref FixmeSnsTopic
+  #       - !Ref DMIQSnsTopic
+  #       - !Ref IotPlatform1SnsTopic
+  #       - !Ref IotPlatform2SnsTopic
+  #       - !Ref DBOSnsTopic
+  #       - !Ref DealerMobileAppsSnsTopic
+  #       - !Ref ATGSnsTopic
+
+  DIOpsSnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: DI Ops TEAM Access Requests
+      TopicName: !Sub 
+        - di_operations-${TopicSuffix}
+        - TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+      Subscription:
+        - Endpoint: !FindInMap [TeamSpecific, DIOps, ChannelEmail]
+          Protocol: EMAIL
+
+  FixmeSnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: FIXME TEAM Access Requests
+      TopicName: !Sub
+        - fixme-${TopicSuffix}
+        - TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+  
+  DMIQSnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: DMIQ TEAM Access Requests
+      TopicName: !Sub
+        - dmiq-${TopicSuffix}
+        - TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+  
+  IotPlatform1SnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: IoT Platform 1 TEAM Access Requests
+      TopicName: !Sub
+        - iotplatform1-${TopicSuffix}
+        - TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+  
+  IotPlatform2SnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: IoT Platform 2 TEAM Access Requests
+      TopicName: !Sub
+        - iot_platform_2-${TopicSuffix}
+        - TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+  
+  DBOSnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: DBO TEAM Access Requests
+      TopicName: !Sub
+        - dbo-${TopicSuffix}
+        - TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+  
+  DealerMobileAppsSnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: Dealer Mobile Apps TEAM Access Requests
+      TopicName: !Sub
+        - dapps-${TopicSuffix}
+        - TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+  
+  ATGSnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: ATG TEAM Access Requests
+      TopicName: !Sub
+        - atg-${TopicSuffix}
+        - TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+
+  PublishToTeamTopics:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:Publish
+            Resource:
+              - !Ref DIOpsSnsTopic
+              - !Ref FixmeSnsTopic
+              - !Ref DMIQSnsTopic
+              - !Ref IotPlatform1SnsTopic
+              - !Ref IotPlatform2SnsTopic
+              - !Ref DBOSnsTopic
+              - !Ref DealerMobileAppsSnsTopic
+              - !Ref ATGSnsTopic
+
+# Lambda function that checks the incoming message from the router Queue
+# looking at the "role" in the reuquest, it selects the correct topic from above
+# to send the notification. The role name and the topics are prefixed with the team tag,
+# i.e. DI_OPERATIONS-Admin (role) and di_operations-team-access-requests (topic)
+
+  RequestRouterLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Architectures:
+        - arm64
+      Handler: index.handler
+      Runtime: nodejs20.x
+      Description: Lambda to route TEAM access requests to the correct SNS topic based on the role
+      FunctionName: !FindInMap [Settings, RoutingFunction, name]
+      Environment:
+        Variables:
+          TopicSuffix: !FindInMap [Settings, TopicSuffix, value]
+          Topics: !Join 
+            - ','
+            - - !Ref DIOpsSnsTopic
+              - !Ref FixmeSnsTopic
+              - !Ref DMIQSnsTopic
+              - !Ref IotPlatform1SnsTopic
+              - !Ref IotPlatform2SnsTopic
+              - !Ref DBOSnsTopic
+              - !Ref DealerMobileAppsSnsTopic
+              - !Ref ATGSnsTopic
+      Events:
+        MessageToRouterTopic:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt RequestRouterSqsQueue.Arn
+            Enabled: true
+      InlineCode: |
+        const { SNSClient, PublishCommand } = require('@aws-sdk/client-sns');
+        
+        exports.handler = async (event) => {
+          const sns = new SNSClient({ region: process.env.AWS_REGION });
+          const topics = process.env.Topics.split(',');
+
+          for (const record of event.Records) {
+            const body = JSON.parse(record.body);
+            const message = JSON.parse(body.Message);
+            console.log(message)
+            const role = message.role;
+            const team = role.split('-')[0];
+            const topic = topics.find(topic => topic.split(':').pop() === `${team.toLowerCase()}-${process.env.TopicSuffix}`);
+            if (topic) {
+              console.log(`Sending message to topic: ${topic}`);
+              const input = {
+                TopicArn: topic,
+                Subject: body.Subject,
+                Message: body.Message,
+              };
+              const command = new PublishCommand(input);
+              await sns.send(command);
+            } else {
+              console.error(`topic not found: ${team.toLowerCase()}-${process.env.TopicSuffix}`);
+            }
+          }
+        };
+      Policies:
+        - !Ref PublishToTeamTopics
+      PropagateTags: true

--- a/notifications/template.yaml
+++ b/notifications/template.yaml
@@ -55,33 +55,6 @@ Resources:
       TopicArn: !FindInMap [Settings, TeamNotificationsTopic, arn]
       Endpoint: !GetAtt RequestRouterSqsQueue.Arn
 
-  # SnsTopicPolicy:
-  #   Type: AWS::SNS::TopicPolicy
-  #   Properties:
-  #     PolicyDocument:
-  #       Version: '2012-10-17'
-  #       Statement:
-  #         - Effect: Allow
-  #           Principal:
-  #             Service: sns.amazonaws.com
-  #           Action:
-  #             - sns:Publish
-  #           Resource: '*-team-access-requests'
-  #           Condition:
-  #             ArnEquals:
-  #               aws:SourceArn: !Sub
-  #                 - arn:${AWS::Region}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}
-  #                 - FunctionName: !FindInMap [Settings, RoutingFunction, name]
-  #     Topics:
-  #       - !Ref DIOpsSnsTopic
-  #       - !Ref FixmeSnsTopic
-  #       - !Ref DMIQSnsTopic
-  #       - !Ref IotPlatform1SnsTopic
-  #       - !Ref IotPlatform2SnsTopic
-  #       - !Ref DBOSnsTopic
-  #       - !Ref DealerMobileAppsSnsTopic
-  #       - !Ref ATGSnsTopic
-
   DIOpsSnsTopic:
     Type: AWS::SNS::Topic
     Properties:


### PR DESCRIPTION
![hold](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbzNraTlqMnpiYTNuaWZndHF4OHo3Znc3bWpobGxiZzF2aWIxdG1tOCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Db7KR3SLgRUVfqKp0V/giphy.gif)

## Background
---
TEAM application only allows for on SNS topic to which notifications can be sent. Since we want teams to monitor and approve their own requests and avoid alert fatigue, we need a way to route requests to the correct team.

## Changes Made
---
- Added SQS Queue with a subscription to the SNS topic created by the TEAM application
- Added SNS Topic for teams on-boarded or soon to be on-boarded prefixed with the team tag/ID
- Added an lambda function to route messages to the correct SNS Topic based on the role requested. Each team has an admin role defined in db-aws-teamroles with the team tag/DI as the prefix, i.e. `DI_OPERATIONS-Admin`. Using this prefix with the Topics allows for easy routing.